### PR TITLE
fix context tainted in-place by context processors

### DIFF
--- a/aiohttp_jinja2/__init__.py
+++ b/aiohttp_jinja2/__init__.py
@@ -12,8 +12,8 @@ __all__ = ('setup', 'get_env', 'render_template', 'template')
 
 
 APP_KEY = 'aiohttp_jinja2_environment'
-REQUEST_CONTEXT_KEY = 'aiohttp_jinja2_context'
 APP_CONTEXT_PROCESSORS_KEY = 'aiohttp_jinja2_context_processors'
+REQUEST_CONTEXT_KEY = 'aiohttp_jinja2_context'
 
 
 def setup(app, *args, app_key=APP_KEY, context_processors=(),
@@ -58,10 +58,8 @@ def render_string(template_name, request, context, *, app_key=APP_KEY):
         text = "context should be mapping, not {}".format(type(context))
         # same reason as above
         raise web.HTTPInternalServerError(reason=text, text=text)
-    if REQUEST_CONTEXT_KEY in request:
-        for k, v in request.get(REQUEST_CONTEXT_KEY, {}).items():
-            if k not in context:
-                context[k] = v
+    if request.get(REQUEST_CONTEXT_KEY):
+        context = dict(request[REQUEST_CONTEXT_KEY], **context)
     text = template.render(context)
     return text
 

--- a/tests/test_context_processors.py
+++ b/tests/test_context_processors.py
@@ -95,25 +95,19 @@ def test_context_not_tainted(test_client, loop):
     def func(request):
         return global_context
 
-    app = web.Application(loop=loop, middlewares=[
-            aiohttp_jinja2.context_processors_middleware])
-    aiohttp_jinja2.setup(app, loader=jinja2.DictLoader(
-        {'tmpl.jinja2':
-         'foo: {{ foo }}, bar: {{ bar }}, path: {{ request.path }}'}))
-
-    app['aiohttp_jinja2_context_processors'] = (
-        aiohttp_jinja2.request_processor,
-        asyncio.coroutine(
-            lambda request: {'foo': 1, 'bar': 2}),
-    )
+    app = web.Application(loop=loop)
+    aiohttp_jinja2.setup(
+        app,
+        loader=jinja2.DictLoader({'tmpl.jinja2': 'foo: {{ foo }}'}),
+        context_processors=[asyncio.coroutine(
+                                lambda request: {'foo': 1})])
 
     app.router.add_get('/', func)
-
     client = yield from test_client(app)
 
     resp = yield from client.get('/')
     assert 200 == resp.status
     txt = yield from resp.text()
-    assert 'foo: 1, bar: 2, path: /' == txt
+    assert 'foo: 1' == txt
 
     assert 'foo' not in global_context


### PR DESCRIPTION
Currently context processors push their data directly into the passed context. Typically modifying passed arguments should be avoided, as this may lead to errors and race conditions depending on circumstances. This PR solves the problem by creating a copy of context when there is some data to be inserted by context processors, and includes the regression test.