### PR TITLE
Allow to pass custom status code in render_template function

### DIFF
--- a/aiohttp_jinja2/__init__.py
+++ b/aiohttp_jinja2/__init__.py
@@ -65,8 +65,8 @@ def render_string(template_name, request, context, *, app_key=APP_KEY):
 
 
 def render_template(template_name, request, context, *,
-                    app_key=APP_KEY, encoding='utf-8'):
-    response = web.Response()
+                    app_key=APP_KEY, encoding='utf-8', status=200):
+    response = web.Response(status=status)
     if context is None:
         context = {}
     text = render_string(template_name, request, context, app_key=app_key)

--- a/tests/test_simple_renderer.py
+++ b/tests/test_simple_renderer.py
@@ -187,6 +187,33 @@ def test_render_template(loop, test_client):
 
 
 @asyncio.coroutine
+def test_render_template_custom_status(loop, test_client):
+
+    @asyncio.coroutine
+    def func(request):
+        return aiohttp_jinja2.render_template(
+            'tmpl.jinja2', request,
+            {'head': 'HEAD', 'text': 'text'}, status=404)
+
+    template = '<html><body><h1>{{head}}</h1>{{text}}</body></html>'
+
+    app = web.Application(loop=loop)
+    aiohttp_jinja2.setup(app, loader=jinja2.DictLoader({
+        'tmpl.jinja2': template
+    }))
+
+    app.router.add_route('*', '/', func)
+
+    client = yield from test_client(app)
+
+    resp = yield from client.get('/')
+
+    assert 404 == resp.status
+    txt = yield from resp.text()
+    assert '<html><body><h1>HEAD</h1>text</body></html>' == txt
+
+
+@asyncio.coroutine
 def test_template_not_found(loop):
 
     @asyncio.coroutine


### PR DESCRIPTION
Currently `render_template` does not allow to pass custom status code, for example 404 and render template. Now it is needed to `render_string` and manually prepare the response.