### PR TITLE
Add Sphinx page for API

### DIFF
--- a/aiohttp_jinja2/__init__.py
+++ b/aiohttp_jinja2/__init__.py
@@ -10,7 +10,7 @@ from .helpers import GLOBAL_HELPERS
 
 __version__ = '0.16.0'
 
-__all__ = ('setup', 'get_env', 'render_template', 'template')
+__all__ = ('setup', 'get_env', 'render_template', 'render_string', 'template')
 
 
 APP_CONTEXT_PROCESSORS_KEY = 'aiohttp_jinja2_context_processors'

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -39,7 +39,18 @@ parameters.
 
 Example of usage
 ^^^^^^^^^^^^^^^^
-here we go
+Simple initialization::
+
+   import jinja2
+   import aiohttp_jinja2
+   from aiohttp import web
+
+
+   app = web.Application()
+   aiohttp_jinja2.setup(
+      app,
+      loader=jinja2.FileSystemLoader('/path/to/templates/folder'),
+   )
 
 
 .. function:: render_string(template_name, request, context, *,
@@ -73,5 +84,14 @@ here we go
 
 Example of usage
 ^^^^^^^^^^^^^^^^
+Assuming the initialization from the example about has been done::
 
-here we go
+   async def handler(request):
+      context = {'foo': 'bar'}
+      response = aiohttp_jinja2.render_template('tmpl.jinja2',
+                                                request,
+                                                context)
+      return response
+
+   app.router.add_get('/tmpl', handler)
+

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -18,8 +18,8 @@ parameters.
    :param app: :class:`aiohttp.web.Application` instance to initialize template
                system on.
 
-   :param str app_key: key that will be used to access templating environment
-                       from application dictionary object.
+   :param str app_key: optional key that will be used to access templating
+                       environment from application dictionary object.
 
    :param context_processors: list of :ref:`aiohttp-web-middlewares`. These are
                               context processors used to rewrite or inject some
@@ -37,6 +37,36 @@ parameters.
    :param ``*args``: positional arguments passed into environment constructor.
    :param ``**kwargs``: any arbitrary keyword arguments you want to pass to
                         :class:`jinja2.Environment` environment.
+
+
+.. function:: get_env(app, *, app_key)
+
+   Get aiohttp-jinja2 environment from an application instance by key.
+
+   :param app: :class:`aiohttp.web.Application` instance to get variables from.
+
+   :param str app_key: optinal key that will be used to access templating
+                       environment from application dictionary object.
+
+
+.. function:: template(template_name, *, app_key, encoding, status)
+
+   Behaves as a decorator around view functions accepting template name that
+   should be rendered as a result. Supports both synchronous and asynchronous
+   functions.
+
+   :param str template_name: name of the template file that will be looked up
+                             by the loader. Raises a 500 error in case template
+                             was not found.
+
+   :param str app_key: optional key that will be used to access templating
+                       environment from application dictionary object.
+
+   :param str encoding: encoding that will be set as a charset property on the
+                        response for rendered template, default to utf-8.
+
+   :params int status: http status code that will be set on resulting response.
+
 
 Example of usage
 ^^^^^^^^^^^^^^^^

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,8 +1,7 @@
 API
 ===
 
-This page describes module API with detailed explanations of the functions
-parameters.
+Describes the module API with detailed explanations of functions parameters.
 
 .. module:: aiohttp_jinja2
 .. highlight:: python
@@ -12,22 +11,22 @@ parameters.
                     filters=None, default_helpers=True, **kwargs)
 
    Function responsible for initializing templating system on application. This
-   one is required to be called first in order to start using this package with
-   your application.
+￼  much be called before freezing or running the application in order to use
+   *aiohttp-jinja*.
 
    :param app: :class:`aiohttp.web.Application` instance to initialize template
                system on.
 
    :param str app_key: optional key that will be used to access templating
-                       environment from application dictionary object.
+                       environment from application dictionary object. Defaults
+                       to `aiohttp_jinja2_environment`.
 
    :param context_processors: list of :ref:`aiohttp-web-middlewares`. These are
                               context processors used to rewrite or inject some
                               variables during the processing of a request.
    :type context_processors: :class:`list`
 
-   :param filters: list of functions allowing to modify variables within a
-                   template.
+   :param filters: extra jinja filters http://jinja.pocoo.org/docs/2.10/templates/#filters
    :type filters: :class:`list`
 
    :param bool default_helpers: whether to use default global helper in
@@ -45,22 +44,24 @@ parameters.
 
    :param app: :class:`aiohttp.web.Application` instance to get variables from.
 
-   :param str app_key: optinal key that will be used to access templating
-                       environment from application dictionary object.
+   :param str app_key: optional key that will be used to access templating
+                           environment from application dictionary object. Defaults
+                           to `aiohttp_jinja2_environment`.
 
 
 .. function:: template(template_name, *, app_key, encoding, status)
 
    Behaves as a decorator around view functions accepting template name that
-   should be rendered as a result. Supports both synchronous and asynchronous
-   functions.
+   should be used to render the response. Supports both synchronous and
+   asynchronous functions.
 
    :param str template_name: name of the template file that will be looked up
                              by the loader. Raises a 500 error in case template
                              was not found.
 
    :param str app_key: optional key that will be used to access templating
-                       environment from application dictionary object.
+                       environment from application dictionary object. Defaults
+                       to `aiohttp_jinja2_environment`.
 
    :param str encoding: encoding that will be set as a charset property on the
                         response for rendered template, default to utf-8.
@@ -92,25 +93,29 @@ Simple initialization::
    :param str template_name: Name of the template you want to render. Usually
                              it's a filename without extension on your
                              filesystem.
-   :param request: request to the main application that implies template
-                   rendering.
+   :param request: aiohttp request associated with an application where
+                   aiohttp-jinja rendering is configured.
    :type request: :class:`aiohttp.web.Request`
 
-   :param context: set of variables that are used to fill the template.
-   :param str app_key: is an optional key for application dict.
+   :param dict context: dictionary used as context when rendering the template.
+   :param str app_key: optional key that will be used to access templating
+                       environment from application dictionary object. Defaults
+                       to `aiohttp_jinja2_environment`.
 
 
 .. function:: render_template(template_name, request, context, *,
                               app_key=APP_KEY, encoding='utf-8', status=200)
 
    :param str template_name: Name of the template you want to render.
-   :param request: request to the main application that implies template
-                   rendering.
+   :param request: aiohttp request associated with an application where
+                   aiohttp-jinja rendering is configured.
    :type request: :class:`aiohttp.web.Request`
 
-   :param dict context: set of variables that are used to fill the template.
-   :param app_key: is an optional key for application dict.
-   :param int status: desc.
+   :param dict context: dictionary used as context when rendering the template.
+   :param str app_key: optional key that will be used to access templating
+                       environment from application dictionary object. Defaults
+                       to `aiohttp_jinja2_environment`.
+   :param int status: http status code that will be set on resulting response.
 
 
 Example of usage

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -26,7 +26,8 @@ Describes the module API with detailed explanations of functions parameters.
                               variables during the processing of a request.
    :type context_processors: :class:`list`
 
-   :param filters: extra jinja filters http://jinja.pocoo.org/docs/2.10/templates/#filters
+   :param filters: extra jinja filters (`link to docs
+                   <http://jinja.pocoo.org/docs/2.10/templates/#filters>`).
    :type filters: :class:`list`
 
    :param bool default_helpers: whether to use default global helper in

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,36 @@
+API
+===
+
+
+.. module:: aiohttp_jinja2
+.. highlight:: python
+
+
+.. function:: setup(app, *args, app_key=APP_KEY, context_processors=(),
+                    filters=None, default_helpers=True, **kwargs)
+
+   Function responsible for initializing templating system on application. This
+   one is required to be called first in order to start using this package with
+   your application.
+
+   :param app: :class:`aiohttp.web.Application` instance to initialize template
+               system on.
+
+   :param str app_key: key that will be used to access templating environment
+                       from application dictionary object.
+
+   :param context_processors: list of :ref:`aiohttp-web-middlewares`. These are
+                              context processors used to rewrite or inject some
+                              variables during the processing of a request.
+   :type context_processors: :class:`list`
+
+   :param filters: desc.
+   :type filters: :class:`list`
+
+   :param bool default_helpers: whether to use default global helper in
+                                templates provided by package
+                                :mod:`aiohttp_jinja2.helpers` or not.
+
+   :param ``*args``: positional arguments passed into environment constructor.
+   :param ``**kwargs``: any arbitrary keyword arguments you want to pass to
+                        :class:`jinja2.Environment` environment.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -26,7 +26,8 @@ parameters.
                               variables during the processing of a request.
    :type context_processors: :class:`list`
 
-   :param filters: desc.
+   :param filters: list of functions allowing to modify variables within a
+                   template.
    :type filters: :class:`list`
 
    :param bool default_helpers: whether to use default global helper in

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,6 +1,8 @@
 API
 ===
 
+This page describes module API with detailed explanations of the functions
+parameters.
 
 .. module:: aiohttp_jinja2
 .. highlight:: python
@@ -34,3 +36,42 @@ API
    :param ``*args``: positional arguments passed into environment constructor.
    :param ``**kwargs``: any arbitrary keyword arguments you want to pass to
                         :class:`jinja2.Environment` environment.
+
+Example of usage
+^^^^^^^^^^^^^^^^
+here we go
+
+
+.. function:: render_string(template_name, request, context, *,
+                            app_key=APP_KEY)
+
+   Renders template specified and returns resulting string.
+
+   :param str template_name: Name of the template you want to render. Usually
+                             it's a filename without extension on your
+                             filesystem.
+   :param request: request to the main application that implies template
+                   rendering.
+   :type request: :class:`aiohttp.web.Request`
+
+   :param context: set of variables that are used to fill the template.
+   :param str app_key: is an optional key for application dict.
+
+
+.. function:: render_template(template_name, request, context, *,
+                              app_key=APP_KEY, encoding='utf-8', status=200)
+
+   :param str template_name: Name of the template you want to render.
+   :param request: request to the main application that implies template
+                   rendering.
+   :type request: :class:`aiohttp.web.Request`
+
+   :param dict context: set of variables that are used to fill the template.
+   :param app_key: is an optional key for application dict.
+   :param int status: desc.
+
+
+Example of usage
+^^^^^^^^^^^^^^^^
+
+here we go

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -137,7 +137,7 @@ html_theme_options = {
     'github_repo': 'aiohttp_jinja2',
     'github_button': True,
     'github_banner': True,
-    'travis_button': True,
+    'travis_button': 'aio-libs/aiohttp-jinja2',
     'pre_bg': '#FFF6E5',
     'note_bg': '#E5ECD1',
     'note_border': '#BFCF8C',

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -177,7 +177,7 @@ Please feel free to file an issue on `bug tracker
 <https://github.com/aio-libs/aiohttp_jinja2/issues>`_ if you have found a bug
 or have some suggestion for library improvement.
 
-The library uses `Travis <https://travis-ci.org/aio-libs/aiohttp_jinja2>`_ for
+The library uses `Travis <https://travis-ci.org/aio-libs/aiohttp-jinja2>`_ for
 Continuous Integration.
 
 IRC channel

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -303,8 +303,17 @@ Glossary
        An endpoint that returns http response.
 
 
+Contents
+--------
+
+.. toctree::
+   :maxdepth: 2
+
+   api
+
+
 Indices and tables
-==================
+------------------
 
 * :ref:`genindex`
 * :ref:`search`


### PR DESCRIPTION
## Rationale 
We need to have better documentation for functions that package provides. This PR addresses  #157 issue.

## Changes
* Add `api` page with some usage examples
* Update travis button to correctly redirect to Travis page

## Testing
![image](https://user-images.githubusercontent.com/3602533/31076719-40c46ae4-a784-11e7-99ae-955f82d778be.png)

@asvetlov is there anything like staging(?) for the documentation where other users can check how it looks for such PRs with documentation updates?