### PR TITLE
Autoescape temlpates by default

### DIFF
--- a/aiohttp_jinja2/__init__.py
+++ b/aiohttp_jinja2/__init__.py
@@ -24,6 +24,8 @@ def setup(app, *args, app_key=APP_KEY, context_processors=(),
         env.globals.update(GLOBAL_HELPERS)
     if filters is not None:
         env.filters.update(filters)
+    if 'autoescape' not in kwargs:
+        env.autoescape = aiohttp_jinja2_autoescape
     app[app_key] = env
     if context_processors:
         app[APP_CONTEXT_PROCESSORS_KEY] = context_processors
@@ -32,6 +34,12 @@ def setup(app, *args, app_key=APP_KEY, context_processors=(),
     env.globals['app'] = app
 
     return env
+
+
+def aiohttp_jinja2_autoescape(template):
+    if template is None:
+        return True
+    return template.endswith(('.html', '.htm', '.xml', '.xhtml', '.jinja2'))
 
 
 def get_env(app, *, app_key=APP_KEY):

--- a/aiohttp_jinja2/__init__.py
+++ b/aiohttp_jinja2/__init__.py
@@ -25,7 +25,7 @@ def setup(app, *args, app_key=APP_KEY, context_processors=(),
     if filters is not None:
         env.filters.update(filters)
     if 'autoescape' not in kwargs:
-        env.autoescape = aiohttp_jinja2_autoescape
+        env.autoescape = lambda _: True
     app[app_key] = env
     if context_processors:
         app[APP_CONTEXT_PROCESSORS_KEY] = context_processors
@@ -34,12 +34,6 @@ def setup(app, *args, app_key=APP_KEY, context_processors=(),
     env.globals['app'] = app
 
     return env
-
-
-def aiohttp_jinja2_autoescape(template):
-    if template is None:
-        return True
-    return template.endswith(('.html', '.htm', '.xml', '.xhtml', '.jinja2'))
 
 
 def get_env(app, *, app_key=APP_KEY):


### PR DESCRIPTION
If a custom override for autoescape is not present the default behaviour
will be to escape templates with extensions html, htm, xhtml, xml, and
jinja2.

Closes #177 