### PR TITLE
Upd docs with user in context example

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7,11 +7,11 @@ Describes the module API with detailed explanations of functions parameters.
 .. highlight:: python
 
 
-.. function:: setup(app, *args, app_key=APP_KEY, context_processors=(),
+.. function:: setup(app, *args, app_key=APP_KEY, context_processors=(), \
                     filters=None, default_helpers=True, **kwargs)
 
-   Function responsible for initializing templating system on application. This
-￼  much be called before freezing or running the application in order to use
+   Function responsible for initializing templating system on application. It
+   must be called before freezing or running the application in order to use
    *aiohttp-jinja*.
 
    :param app: :class:`aiohttp.web.Application` instance to initialize template

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -86,7 +86,7 @@ Simple initialization::
    )
 
 
-.. function:: render_string(template_name, request, context, *,
+.. function:: render_string(template_name, request, context, *, \
                             app_key=APP_KEY)
 
    Renders template specified and returns resulting string.
@@ -104,7 +104,7 @@ Simple initialization::
                        to `aiohttp_jinja2_environment`.
 
 
-.. function:: render_template(template_name, request, context, *,
+.. function:: render_template(template_name, request, context, *, \
                               app_key=APP_KEY, encoding='utf-8', status=200)
 
    :param str template_name: Name of the template you want to render.
@@ -121,7 +121,7 @@ Simple initialization::
 
 Example of usage
 ^^^^^^^^^^^^^^^^
-Assuming the initialization from the example about has been done::
+Assuming the initialization from the example above has been done::
 
    async def handler(request):
       context = {'foo': 'bar'}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -97,6 +97,28 @@ As you can see, there is a built-in :func:`request_processor`, which
 adds current :class:`aiohttp.web.Request` into context of templates
 under ``'request'`` name.
 
+Here is an example of how to add current user dependant logic
+to template (requires ``aiohttp_security`` library)::
+
+    from aiohttp_security import authorized_userid
+
+    async def current_user_ctx_processor(request):
+        userid = await authorized_userid(request)
+        is_anonymous = not bool(userid)
+        return {'current_user': {'is_anonymous': is_anonymous}}
+
+Template::
+
+    <body>
+        <div>
+            {% if current_user.is_anonymous %}
+                <a href="{{ url('login') }}">Login</a>
+            {% else %}
+                <a href="{{ url('logout') }}">Logout</a>
+            {% endif %}
+        </div>
+    </body>
+
 Default Globals
 ...............
 


### PR DESCRIPTION
1. This PR adds and example on how to add current user into template context

2. Along with that I've fixed a couple of sphinx warnings, but..

3. There are a lot of `duplicate object description` warnings, for `render_template`, `get_env` etc because they are present both in `index.rst` and `api.rst`. 
I suppose that `index:Reference` can be merged into api. 
An alternative would be to put  :noindex: (in 5 places)

4. Looks like the `latest` version of docs has not been built in a while (it looks older than `stable`)
