### PR TITLE
Expand typing to tests.

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,24 @@
+[mypy]
+files = aiohttp_jinja2, tests
+check_untyped_defs = True
+follow_imports_for_stubs = True
+disallow_any_decorated = True
+disallow_any_generics = True
+disallow_incomplete_defs = True
+disallow_subclassing_any = True
+disallow_untyped_calls = True
+disallow_untyped_decorators = True
+disallow_untyped_defs = True
+implicit_reexport = False
+no_implicit_optional = True
+show_error_codes = True
+strict_equality = True
+warn_incomplete_stub = True
+warn_redundant_casts = True
+warn_unreachable = True
+warn_unused_ignores = True
+disallow_any_unimported = True
+warn_return_any = True
+
+[mypy-tests.*]
+disallow_untyped_defs = False

--- a/aiohttp_jinja2/__init__.py
+++ b/aiohttp_jinja2/__init__.py
@@ -44,15 +44,15 @@ _ContextProcessor = Callable[[web.Request], Awaitable[Dict[str, Any]]]
 
 class _TemplateWrapped(Protocol):
     @overload
-    async def __call__(self, request: web.Request, /) -> web.StreamResponse:
+    async def __call__(self, request: web.Request) -> web.StreamResponse:
         ...
 
     @overload
-    async def __call__(self, view: AbstractView, /) -> web.StreamResponse:
+    async def __call__(self, view: AbstractView) -> web.StreamResponse:
         ...
 
     @overload
-    async def __call__(self, _self: Any, request: web.Request, /) -> web.StreamResponse:
+    async def __call__(self, _self: Any, request: web.Request) -> web.StreamResponse:
         ...
 
 
@@ -146,15 +146,15 @@ def template(
 ) -> Callable[[_TemplateHandler], _TemplateWrapped]:
     def wrapper(func: _TemplateHandler) -> _TemplateWrapped:
         @overload
-        async def wrapped(request: web.Request, /) -> web.StreamResponse:
+        async def wrapped(request: web.Request) -> web.StreamResponse:
             ...
 
         @overload
-        async def wrapped(view: AbstractView, /) -> web.StreamResponse:
+        async def wrapped(view: AbstractView) -> web.StreamResponse:
             ...
 
         @overload
-        async def wrapped(_self: Any, request: web.Request, /) -> web.StreamResponse:
+        async def wrapped(_self: Any, request: web.Request) -> web.StreamResponse:
             ...
 
         @functools.wraps(func)

--- a/aiohttp_jinja2/__init__.py
+++ b/aiohttp_jinja2/__init__.py
@@ -10,7 +10,6 @@ from typing import (
     Mapping,
     Optional,
     Protocol,
-    Type,
     Union,
     cast,
     overload,

--- a/aiohttp_jinja2/__init__.py
+++ b/aiohttp_jinja2/__init__.py
@@ -61,7 +61,7 @@ if sys.version_info >= (3, 8):
 
 
 else:
-    _TemplateWrapped = Callable[[...], web.StreamResponse]
+    _TemplateWrapped = Callable[..., web.StreamResponse]
 
 
 def setup(

--- a/aiohttp_jinja2/__init__.py
+++ b/aiohttp_jinja2/__init__.py
@@ -45,11 +45,16 @@ _ContextProcessor = Callable[[web.Request], Awaitable[Dict[str, Any]]]
 
 class _TemplateWrapped(Protocol):
     @overload
-    async def __call__(self, request: web.Request, /) -> web.StreamResponse: ...
+    async def __call__(self, request: web.Request, /) -> web.StreamResponse:
+        ...
+
     @overload
-    async def __call__(self, view: AbstractView, /) -> web.StreamResponse: ...
+    async def __call__(self, view: AbstractView, /) -> web.StreamResponse:
+        ...
+
     @overload
-    async def __call__(self, _self: Any, request: web.Request, /) -> web.StreamResponse: ...
+    async def __call__(self, _self: Any, request: web.Request, /) -> web.StreamResponse:
+        ...
 
 
 def setup(

--- a/aiohttp_jinja2/__init__.py
+++ b/aiohttp_jinja2/__init__.py
@@ -54,7 +54,9 @@ if sys.version_info >= (3, 8):
             ...
 
         @overload
-        async def __call__(self, _self: Any, request: web.Request) -> web.StreamResponse:
+        async def __call__(
+            self, _self: Any, request: web.Request
+        ) -> web.StreamResponse:
             ...
 
 

--- a/aiohttp_jinja2/__init__.py
+++ b/aiohttp_jinja2/__init__.py
@@ -1,5 +1,6 @@
 import asyncio
 import functools
+import sys
 import warnings
 from typing import (
     Any,
@@ -9,7 +10,6 @@ from typing import (
     Iterable,
     Mapping,
     Optional,
-    Protocol,
     Union,
     cast,
     overload,
@@ -41,19 +41,25 @@ _TemplateHandler = Union[
 
 _ContextProcessor = Callable[[web.Request], Awaitable[Dict[str, Any]]]
 
+if sys.version_info >= (3, 8):
+    from typing import Protocol
 
-class _TemplateWrapped(Protocol):
-    @overload
-    async def __call__(self, request: web.Request) -> web.StreamResponse:
-        ...
+    class _TemplateWrapped(Protocol):
+        @overload
+        async def __call__(self, request: web.Request) -> web.StreamResponse:
+            ...
 
-    @overload
-    async def __call__(self, view: AbstractView) -> web.StreamResponse:
-        ...
+        @overload
+        async def __call__(self, view: AbstractView) -> web.StreamResponse:
+            ...
 
-    @overload
-    async def __call__(self, _self: Any, request: web.Request) -> web.StreamResponse:
-        ...
+        @overload
+        async def __call__(self, _self: Any, request: web.Request) -> web.StreamResponse:
+            ...
+
+
+else:
+    _TemplateWrapped = Callable[[Any, ...], web.StreamResponse]
 
 
 def setup(

--- a/aiohttp_jinja2/__init__.py
+++ b/aiohttp_jinja2/__init__.py
@@ -43,12 +43,14 @@ _TemplateHandler = Union[
     _SimpleTemplateHandler, _MethodTemplateHandler, _ViewTemplateHandler
 ]
 
+_ContextProcessor = Callable[[web.Request], Awaitable[Dict[str, Any]]]
+
 
 def setup(
     app: web.Application,
     *args: Any,
     app_key: str = APP_KEY,
-    context_processors: Iterable[Callable[[web.Request], Dict[str, Any]]] = (),
+    context_processors: Iterable[_ContextProcessor] = (),
     filters: Optional[Filters] = None,
     default_helpers: bool = True,
     **kwargs: Any,
@@ -109,7 +111,7 @@ def render_string(
 def render_template(
     template_name: str,
     request: web.Request,
-    context: Mapping[str, Any],
+    context: Optional[Mapping[str, Any]],
     *,
     app_key: str = APP_KEY,
     encoding: str = "utf-8",

--- a/aiohttp_jinja2/__init__.py
+++ b/aiohttp_jinja2/__init__.py
@@ -61,7 +61,7 @@ if sys.version_info >= (3, 8):
 
 
 else:
-    _TemplateWrapped = Callable[[Any, ...], web.StreamResponse]
+    _TemplateWrapped = Callable[[...], web.StreamResponse]
 
 
 def setup(

--- a/aiohttp_jinja2/helpers.py
+++ b/aiohttp_jinja2/helpers.py
@@ -9,11 +9,13 @@ import jinja2
 from aiohttp import web
 from yarl import URL
 
-
 if sys.version_info >= (3, 8):
     from typing import TypedDict
+    
     class _Context(TypedDict, total=False):
         app: web.Application
+
+
 else:
     _Context = Dict[str, Any]
 

--- a/aiohttp_jinja2/helpers.py
+++ b/aiohttp_jinja2/helpers.py
@@ -11,7 +11,7 @@ from yarl import URL
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict
-    
+
     class _Context(TypedDict, total=False):
         app: web.Application
 

--- a/aiohttp_jinja2/helpers.py
+++ b/aiohttp_jinja2/helpers.py
@@ -2,15 +2,20 @@
 useful context functions, see
 http://jinja.pocoo.org/docs/dev/api/#jinja2.contextfunction
 """
-from typing import Dict, TypedDict, Union
+import sys
+from typing import Any, Dict, Union
 
 import jinja2
 from aiohttp import web
 from yarl import URL
 
 
-class _Context(TypedDict, total=False):
-    app: web.Application
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+    class _Context(TypedDict, total=False):
+        app: web.Application
+else:
+    _Context = Dict[str, Any]
 
 
 @jinja2.contextfunction

--- a/aiohttp_jinja2/helpers.py
+++ b/aiohttp_jinja2/helpers.py
@@ -3,7 +3,7 @@ useful context functions, see
 http://jinja.pocoo.org/docs/dev/api/#jinja2.contextfunction
 """
 import sys
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional, Union
 
 import jinja2
 from aiohttp import web
@@ -21,7 +21,7 @@ else:
 
 
 @jinja2.contextfunction
-def url_for(context: _Context, __route_name: str, **parts: Union[str, int]) -> URL:
+def url_for(context: _Context, __route_name: str, query_: Optional[Dict[str, str]] = None, **parts: Union[str, int]) -> URL:
     """Filter for generating urls.
 
     Usage: {{ url('the-view-name') }} might become "/path/to/view" or
@@ -29,10 +29,6 @@ def url_for(context: _Context, __route_name: str, **parts: Union[str, int]) -> U
     might become "/items/1?active=true".
     """
     app = context["app"]
-
-    query = None
-    if "query_" in parts:
-        query = str(parts.pop("query_"))
 
     parts_clean: Dict[str, str] = {}
     for key in parts:
@@ -52,8 +48,8 @@ def url_for(context: _Context, __route_name: str, **parts: Union[str, int]) -> U
         parts_clean[key] = val
 
     url = app.router[__route_name].url_for(**parts_clean)
-    if query:
-        url = url.with_query(query)
+    if query_:
+        url = url.with_query(query_)
     return url
 
 

--- a/aiohttp_jinja2/helpers.py
+++ b/aiohttp_jinja2/helpers.py
@@ -21,7 +21,12 @@ else:
 
 
 @jinja2.contextfunction
-def url_for(context: _Context, __route_name: str, query_: Optional[Dict[str, str]] = None, **parts: Union[str, int]) -> URL:
+def url_for(
+    context: _Context,
+    __route_name: str,
+    query_: Optional[Dict[str, str]] = None,
+    **parts: Union[str, int]
+) -> URL:
     """Filter for generating urls.
 
     Usage: {{ url('the-view-name') }} might become "/path/to/view" or

--- a/aiohttp_jinja2/helpers.py
+++ b/aiohttp_jinja2/helpers.py
@@ -2,7 +2,7 @@
 useful context functions, see
 http://jinja.pocoo.org/docs/dev/api/#jinja2.contextfunction
 """
-from typing import Any, Dict, TypedDict, Union, cast
+from typing import Dict, TypedDict, Union
 
 import jinja2
 from aiohttp import web

--- a/tests/test_context_processors.py
+++ b/tests/test_context_processors.py
@@ -1,3 +1,5 @@
+from typing import Dict, Union
+
 import jinja2
 from aiohttp import web
 
@@ -17,7 +19,7 @@ async def test_context_processors(aiohttp_client):
         ),
     )
 
-    async def processor(request):
+    async def processor(request: web.Request) -> Dict[str, Union[str, int]]:
         return {"foo": 1, "bar": "should be overwriten"}
 
     app["aiohttp_jinja2_context_processors"] = (

--- a/tests/test_simple_renderer.py
+++ b/tests/test_simple_renderer.py
@@ -281,7 +281,9 @@ async def test_render_can_disable_autoescape(aiohttp_client):
 
 
 async def test_render_bare_funcs_deprecated(aiohttp_client):
-    def wrapper(func: Callable[[web.Request], Awaitable[_T]]) -> Callable[[web.Request], Awaitable[_T]]:
+    def wrapper(
+        func: Callable[[web.Request], Awaitable[_T]]
+    ) -> Callable[[web.Request], Awaitable[_T]]:
         async def wrapped(request: web.Request) -> _T:
             with pytest.warns(
                 DeprecationWarning, match="Bare functions are deprecated"

--- a/tests/test_simple_renderer.py
+++ b/tests/test_simple_renderer.py
@@ -292,7 +292,7 @@ async def test_render_bare_funcs_deprecated(aiohttp_client):
 
         return wrapped
 
-    @wrapper
+    @wrapper  # type: ignore[arg-type]  # Deprecated functionality
     @aiohttp_jinja2.template("tmpl.jinja2")
     def func(request: web.Request) -> Dict[str, str]:
         return {"text": "OK"}


### PR DESCRIPTION
To help ensure annotations are correctly checked (e.g. as mentioned in #354), this configures Mypy to perform checks on the tests which actually make use of the functions, and thus can detect any problems using them together.

There are still a couple of errors coming through. The primary one seems to be my recent change to `template()` return type, which I think might need to use an overload rather than a Union, but I'm struggling to figure out the correct way to do it.