### PR TITLE
Run mypy against tests on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ fmt:
 
 .PHONY: lint
 lint: fmt
-	mypy --strict aiohttp_jinja2
+	mypy --strict
 
 .PHONY: test
 test:


### PR DESCRIPTION
By removing the directory argument, it will now check everything listed in the .mypy.ini file.

Tests will pass once the other PR is merged.