### PR TITLE
removing f-strings (they are supported py3.6+)

### DIFF
--- a/aiohttp_jinja2/__init__.py
+++ b/aiohttp_jinja2/__init__.py
@@ -110,7 +110,7 @@ def _render_string(
     try:
         template = env.get_template(template_name)
     except jinja2.TemplateNotFound as e:
-        text = f"Template '{template_name}' not found"
+        text = "Template {} not found".format(template_name)
         raise web.HTTPInternalServerError(reason=text, text=text) from e
     if not isinstance(context, Mapping):
         text = "context should be mapping, not {}".format(type(context))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
Replace f-strings with .format()

<!-- Please give a short brief about these changes. -->

I replaced the f-strings, because I used this package with python 3.5, but I got a syntax error, since f-strings were introduced from python 3.6+

## Are there changes in behavior for the user?

No

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
