### PR TITLE
Fix deprecation warning from Jinja 3.0

### DIFF
--- a/aiohttp_jinja2/helpers.py
+++ b/aiohttp_jinja2/helpers.py
@@ -20,7 +20,7 @@ else:
     _Context = Dict[str, Any]
 
 
-@jinja2.contextfunction
+@jinja2.pass_context
 def url_for(
     context: _Context,
     __route_name: str,
@@ -58,7 +58,7 @@ def url_for(
     return url
 
 
-@jinja2.contextfunction
+@jinja2.pass_context
 def static_url(context: _Context, static_file_path: str) -> str:
     """Filter for generating urls for static files.
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ alabaster>=0.6.2
 attrs==21.2.0
 coverage==5.5
 flake8==3.9.2
-jinja2==2.11.3
+jinja2==3.0.1
 multidict==5.1.0
 mypy==0.812; implementation_name=="cpython"
 pre-commit==2.12.1
@@ -13,5 +13,5 @@ pytest-aiohttp==0.3.0
 pytest-cov==2.11.1
 pytest-cov==2.11.1
 pytest-sugar==0.9.4
-sphinx==4.0.0
+sphinx==4.0.2
 yarl==1.6.3

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def read(f):
     return open(os.path.join(os.path.dirname(__file__), f)).read().strip()
 
 
-install_requires = ["aiohttp>=3.6.3", "jinja2>=3.0.1", "typing_extensions>=3.7.4"]
+install_requires = ["aiohttp>=3.6.3", "jinja2>=3.0.0", "typing_extensions>=3.7.4"]
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def read(f):
     return open(os.path.join(os.path.dirname(__file__), f)).read().strip()
 
 
-install_requires = ["aiohttp>=3.6.3", "jinja2>=2.10.1", "typing_extensions>=3.7.4"]
+install_requires = ["aiohttp>=3.6.3", "jinja2>=3.0.1", "typing_extensions>=3.7.4"]
 
 
 setup(


### PR DESCRIPTION
Fix for:

`DeprecationWarning: 'contextfunction' is renamed to 'pass_context', the old name will be removed in Jinja 3.1`