### PR TITLE
PR for issue aio-libs/aiohttp-jinja2#451

### DIFF
--- a/aiohttp_jinja2/__init__.py
+++ b/aiohttp_jinja2/__init__.py
@@ -1,5 +1,6 @@
 import asyncio
 import functools
+import sys
 import warnings
 from typing import (
     Any,
@@ -19,7 +20,11 @@ from typing import (
 import jinja2
 from aiohttp import web
 from aiohttp.abc import AbstractView
-from typing_extensions import Protocol
+
+if sys.version_info >= (3, 8):
+    from typing import Protocol
+else:
+    from typing_extensions import Protocol
 
 from .helpers import GLOBAL_HELPERS
 from .typedefs import Filters

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,11 @@ def read(f):
     return open(os.path.join(os.path.dirname(__file__), f)).read().strip()
 
 
-install_requires = ["aiohttp>=3.6.3", "jinja2>=3.0.0", "typing_extensions>=3.7.4"]
+install_requires = [
+    "aiohttp>=3.6.3",
+    "jinja2>=3.0.0",
+    'typing_extensions>=3.7.4; python_version<"3.8"',
+]
 
 
 setup(


### PR DESCRIPTION
Change typing_extensions dependency to optional for aiohttp_jinja2.

But aiohttp also has typing_extensions in dependencies.

Fixes #451 