### PR TITLE
Support aiohttp 3.14 by using web.RequestKey

### DIFF
--- a/aiohttp_jinja2/__init__.py
+++ b/aiohttp_jinja2/__init__.py
@@ -38,7 +38,7 @@ APP_CONTEXT_PROCESSORS_KEY: Final = web.AppKey[Sequence[_ContextProcessor]](
     "APP_CONTEXT_PROCESSORS_KEY"
 )
 APP_KEY: Final = web.AppKey[jinja2.Environment]("APP_KEY")
-REQUEST_CONTEXT_KEY: Final = "aiohttp_jinja2_context"
+REQUEST_CONTEXT_KEY: Final = web.RequestKey("jinja_context", dict)
 
 _T = TypeVar("_T")
 _P = ParamSpec("_P")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -e .
-aiohttp==3.13.5
+aiohttp==3.14.0
 alabaster>=1.0.0
 coverage==7.14.3
 jinja2==3.1.6

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,6 @@ setup(
     license="Apache 2",
     packages=["aiohttp_jinja2"],
     python_requires=">=3.10",
-    install_requires=("aiohttp>=3.9.0", "jinja2>=3.0.0"),
+    install_requires=("aiohttp>=3.14.0", "jinja2>=3.0.0"),
     include_package_data=True,
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

aiohttp 3.14 has added web.RequestKey, much like AppKey, and will throw a warning if it isn't used. If warnings are treated as exceptions, like this project does, it will cause a test failure. Support both, since it's easy, and doesn't require us to pin aiohttp to an incredibly recent version.

## Are there changes in behavior for the user?

Nope!

## Related issue number

There is no issue filed, sorry.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist -- existing tests cover this
- [ ] Documentation reflects the changes -- it's an invisible change, no docs required
